### PR TITLE
Updated virtual-dom dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "mercury": "^10.1.0"
+    "mercury": "^14.1.0"
   },
   "devDependencies": {
     "w3": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "global": "^4.3.0",
     "observ": "^0.2.0",
     "route-map": "^0.1.0",
-    "virtual-dom": "^1.3.0"
+    "virtual-dom": "^2.1.1"
   },
   "devDependencies": {
     "tape": "^4.0.0",


### PR DESCRIPTION
I was using Mercury-router in a project with Mercury 14.1.0, and I noticed that mercury-router depends on virtual-dom 1.3.0. This was causing an error where using the anchor() function returned a VDOM element that wasn't recognized as a valid VDOM element. Updating to virtual-dom 2.1.1 fixed this issue
