### PR TITLE
route-map dependency unpublished from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-router",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "This is a mercury router component from Raynos : https://gist.github.com/adbf7951bee3fdfe1a65.git",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "geval": "^2.1.1",
     "global": "^4.3.0",
     "observ": "^0.2.0",
-    "route-map": "^0.1.0",
+    "route-map": "azer/route-map#44982d8",
     "virtual-dom": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
https://medium.com/@azerbike/i-ve-just-liberated-my-modules-9045c06be67c

Pointing directly to the Github repo using the latest commit hash as a version.

https://docs.npmjs.com/files/package.json#github-urls
