### PR TITLE
Exported route atom set as function 'go'

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function Render(state, opts) {
     return routeView(opts, state);
 }
 
+RouterComponent.go = router.atom.set;
 RouterComponent.anchor = require('./anchor');
 RouterComponent.render = Render;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-router",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "This is a mercury router component from Raynos : https://gist.github.com/adbf7951bee3fdfe1a65.git",
   "main": "index.js",
   "scripts": {

--- a/router.js
+++ b/router.js
@@ -10,8 +10,6 @@ var routeMap = require('route-map');
 var atom = router.atom = value(String(document.location.href));
 
 function router(channels_map, args) {
-    
-    
     var inPopState = false;
     var popstates = popstate();
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,10 @@ var test = require('tape');
 var window = require('global/window');
 var document = require('global/document');
 
-window.addEventListener = function polyAddEventListneer() { return false; };
+window.history = {};
+window.history.pushState = function polyPushState() {};
+
+window.addEventListener = function polyAddEventListneer() {};
 document.location = { href: '/articles?page=25' };
 
 var router = require('../index');
@@ -17,14 +20,13 @@ test('init', function test_init(t) {
 
     t.ok(router.render, 'has render function');
     t.ok(router.anchor, 'has anchor function');
+    t.ok(router.go, 'has go function');
     t.ok(state, 'state init');
     t.end();
 });
 
 test('router', function test_router(t) {
-    t.equal(
-        atom(),
-        document.location.href,
+    t.equal(atom(), document.location.href,
         'router init with full url, including query string');
 
     t.end();
@@ -35,5 +37,14 @@ test('anchor', function test_anchor(t) {
     var a = anchor({href: link});
 
     t.equal(a.properties.href, link, 'renders full link in href attribute');
+    t.end();
+});
+
+test('go', function navigateTest(t) {
+    var state = router();
+    var link = '/articles?page=26';
+
+    router.go(link);
+    t.equal(state(), link, 'update route through go fn');
     t.end();
 });


### PR DESCRIPTION
This works a lot like `anchor` except it can be called in code without an user event. It lets you update the route without needing to pass the whole application state around.

i.e. 

``` js
appState.route.set('/new-url-path')
```

becomes,

``` js
router.go('/new-url-path')
```
