### PR TITLE
Added fallback route support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Mecury Router looks for two state attributes:
 ## Usage
 
 * `router()` – initialise mercury router state in app state
-* `router.render(routes:Object)` – route path/view mapping in app render
+* `router.render(state:Object, routes:Object, fallback:Function)` – route path/view mapping in app render
 * `router.anchor(attributes:Object, children:VTree|String)` – navigate via `a` html element
 * `router.go(url:String)` – navigate to url directly
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ function RouterComponent() {
     return router().state;
 }
 
-function Render(state, opts) {
-    return routeView(opts, state);
+function Render(state, opts, fallback) {
+    return routeView(opts, state, fallback);
 }
 
 RouterComponent.go = router.atom.set;

--- a/route-view.js
+++ b/route-view.js
@@ -4,7 +4,7 @@ var routeMap = require('route-map');
 
 module.exports = routeView;
 
-function routeView(defn, args) {
+function routeView(defn, args, fallback) {
     var match;
     var res;
 
@@ -20,6 +20,9 @@ function routeView(defn, args) {
     res = match(args.route);
 
     if (!res) {
+        if (fallback) {
+            return fallback();
+        }
         throw new Error('router: no match found');
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,35 @@ test('router', function test_router(t) {
     t.equal(atom(), document.location.href,
         'router init with full url, including query string');
 
+    t.equal('articles', router.render({route: '/articles?page=25'}, {
+        '/': function home() {
+            return 'home';
+        },
+        '/articles': function articles() {
+            return 'articles'
+        }
+    }), 'renders matched route');
+
+    t.equal('fallback', router.render({route: '/books'}, {
+        '/': function home() {
+            return 'home';
+        },
+        '/articles': function articles() {
+            return 'articles'
+        }
+    }, function fallback() { return 'fallback' }), 'renders fallback route');
+
+    t.throws(function missingRoute() {
+        router.render({route: '/books'}, {
+            '/': function home() {
+                return 'home';
+            },
+            '/articles': function articles() {
+                return 'articles'
+            }
+        })
+    }, 'throws an error if no route matches');
+
     t.end();
 });
 


### PR DESCRIPTION
Hi,

I am building an application that supports deep links. As such, I needed a fallback route in the router to show a 404 page if no route matches. This PR adds an optional third `fallback` argument to the `render` function to handle the case when no route matches.
